### PR TITLE
chore: add mac_address

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -237,6 +237,7 @@ A general-purpose programming language and toolchain for maintaining robust, opt
 * [hspak/brightnessztl](https://github.com/hspak/brightnessztl) - A CLI to control device backlight.
 * [thejoshwolfe/hexdump-zip](https://github.com/thejoshwolfe/hexdump-zip) - Produce an annotated hexdump of a zipfile.
 * [kubkon/zacho](https://github.com/kubkon/zacho) - Zig's Mach-O parser.
+* [weskoerber/mac_address](https://github.com/weskoerber/mac_address) - A cross-platform library to retrieve the MAC address from your network interfaces without libc.
 
 
 ## Zig development tools


### PR DESCRIPTION
Hello!

I'd like to add my project, `mac_address`. It's still in its early phases but currently functional on both Windows and Linux (and probably MacOS and *BSD). It's essentially a rewrite of [repnop/mac_address](https://github.com/repnop/mac_address) in Zig.